### PR TITLE
[gstreamer] Reworking the interface a bit

### DIFF
--- a/gst-libs/gst/interfaces/nemovideotexture.c
+++ b/gst-libs/gst/interfaces/nemovideotexture.c
@@ -109,17 +109,7 @@ nemo_gst_video_texture_iface_base_init (NemoGstVideoTextureClass * klass)
 static void
 nemo_gst_video_texture_iface_class_init (NemoGstVideoTextureClass * klass)
 {
-  /**
-   * NemoGstVideoTextureClass::egl-display
-   * EGL Display
-   * Application must provide a valid EGL display to the sink before attempting
-   * to call nemo_gst_video_texture_acquire_frame()
-   */
-  g_object_interface_install_property (klass,
-      g_param_spec_pointer ("egl-display",
-          "EGL display ",
-          "The application provided EGL display to be used for creating EGLImageKHR objects.",
-          G_PARAM_READWRITE));
+  /* Nothing */
 }
 
 /**
@@ -285,4 +275,41 @@ nemo_gst_video_texture_frame_ready (NemoGstVideoTexture * iface, gint frame)
 
   g_signal_emit (G_OBJECT (iface),
       nemo_gst_video_texture_iface_signals[SIGNAL_FRAME_READY], 0, frame);
+}
+
+/**
+ * nemo_gst_video_texture_attach_to_display:
+ * @iface: #NemoGstVideoTexture of a GStreamer element
+ * @dpy: The EGL display to be used by the sink
+ *
+ * Must be called by the application before trying to acquire any frames in order
+ * to inform the sink about the EGL display being used.
+ * The display must remain valid until nemo_gst_video_texture_detach_from_display() gets called
+ */
+void
+nemo_gst_video_texture_attach_to_display (NemoGstVideoTexture * iface, EGLDisplay dpy)
+{
+  NemoGstVideoTextureClass *klass = NEMO_GST_VIDEO_TEXTURE_GET_CLASS (iface);
+
+  if (klass->attach_to_display) {
+    klass->attach_to_display (iface, dpy);
+  }
+}
+
+/**
+ * nemo_gst_video_texture_detach_from_display:
+ * @iface: #NemoGstVideoTexture of a GStreamer element
+ *
+ * Must be called by the application after all the frames have been rendered. Ideally in
+ * response to a frame-ready signal with a negative argument.
+ * Application guarantees calling this from its rendering thread.
+ */
+void
+nemo_gst_video_texture_detach_from_display (NemoGstVideoTexture * iface)
+{
+  NemoGstVideoTextureClass *klass = NEMO_GST_VIDEO_TEXTURE_GET_CLASS (iface);
+
+  if (klass->detach_from_display) {
+    klass->detach_from_display (iface);
+  }
 }

--- a/gst-libs/gst/interfaces/nemovideotexture.h
+++ b/gst-libs/gst/interfaces/nemovideotexture.h
@@ -41,6 +41,7 @@ G_BEGIN_DECLS
 
 typedef void * EGLImageKHR;
 typedef void * EGLSyncKHR;
+typedef void * EGLDisplay;
 
 typedef struct _NemoGstVideoTexture NemoGstVideoTexture;
 typedef struct _NemoGstVideoTextureClass NemoGstVideoTextureClass;
@@ -66,6 +67,8 @@ struct _NemoGstVideoTextureClass
   void (* release_frame) (NemoGstVideoTexture *iface, EGLSyncKHR sync);
   gboolean (* get_frame_info) (NemoGstVideoTexture *iface, NemoGstVideoTextureFrameInfo *info);
   const GstStructure *(* get_frame_qdata)(NemoGstVideoTexture *iface, const GQuark quark);
+  void (* attach_to_display) (NemoGstVideoTexture *iface, EGLDisplay dpy);
+  void (* detach_from_display) (NemoGstVideoTexture *iface);
 
   /*< private >*/
   gpointer                 _gst_reserved[GST_PADDING];
@@ -81,6 +84,8 @@ void     nemo_gst_video_texture_unbind_frame (NemoGstVideoTexture *iface);
 void     nemo_gst_video_texture_release_frame (NemoGstVideoTexture *iface, EGLSyncKHR sync);
 gboolean nemo_gst_video_texture_get_frame_info (NemoGstVideoTexture *iface, NemoGstVideoTextureFrameInfo *info);
 const GstStructure *nemo_gst_video_texture_get_frame_qdata (NemoGstVideoTexture *iface, const GQuark quark);
+void    nemo_gst_video_texture_attach_to_display(NemoGstVideoTexture *iface, EGLDisplay dpy);
+void    nemo_gst_video_texture_detach_from_display(NemoGstVideoTexture *iface);
 
 /* trigger signals */
 void     nemo_gst_video_texture_frame_ready (NemoGstVideoTexture *iface, gint frame);


### PR DESCRIPTION
Remove egl-display property and introduce two new methods. attach_to_display() and detach_from_display()
Some GL implementation like Nexus 4 implementation does not like manipulating the fence objects from
various threads.
We need a mechanism to inform the sink that we are done with rendering so it can destroy any remaining
fence or GL objects from the same rendering thread that created them. This prevents leaking.

While at it, remove egl-display and replace it with a normal function call.
